### PR TITLE
Fix reading of request bodies

### DIFF
--- a/memoryrecorder.go
+++ b/memoryrecorder.go
@@ -39,23 +39,13 @@ func NewMemoryRecorder() *MemoryRecorder {
 	return &MemoryRecorder{}
 }
 
-func makeRequest(in *http.Request) (Request, error) {
+func makeRequest(in *http.Request, body []byte) (Request, error) {
 	// TODO gzip encoding??
-	b, err := ioutil.ReadAll(in.Body)
-	_ = in.Body.Close()
-	if err != nil {
-		return Request{}, errors.New("failed to read request body: " + err.Error())
-	}
-	if len(b) == 0 {
-		b = nil
-	}
-	in.Body = ioutil.NopCloser(bytes.NewReader(b))
-
 	return Request{
 		Method:  in.Method,
 		URL:     in.URL,
 		Headers: in.Header,
-		Body:    b,
+		Body:    body,
 	}, nil
 }
 
@@ -78,9 +68,9 @@ func makeResponse(in *http.Response) (Response, error) {
 	}, nil
 }
 
-func (m *MemoryRecorder) Record(req *http.Request, resp *http.Response, requestReceived time.Time, responseReceived time.Time) error {
+func (m *MemoryRecorder) Record(req *http.Request, requestBody []byte, resp *http.Response, requestReceived time.Time, responseReceived time.Time) error {
 	// TODO this doesn't make a copy of any of the parameters, pointers (and maps) could change via other middleware
-	recReq, err := makeRequest(req)
+	recReq, err := makeRequest(req, requestBody)
 	if err != nil {
 		return err
 	}

--- a/memoryrecorder_test.go
+++ b/memoryrecorder_test.go
@@ -28,7 +28,7 @@ func TestMemoryRecorderRecord(t *testing.T) {
 	end := start.Add(1 * time.Second)
 
 	// TODO does resp need to be a pointer?
-	err := m.Record(req, &resp, start, end)
+	err := m.Record(req, []byte("one=1&two=2"), &resp, start, end)
 
 	require.NoError(t, err)
 

--- a/middleware.go
+++ b/middleware.go
@@ -40,6 +40,9 @@ func Middleware(recorder Recorder) func(http.Handler) http.Handler {
 
 			requestBody, err := replaceBody(r)
 
+			// hack around lack of gzip support
+			r.Header.Del("Accept-Encoding")
+
 			next.ServeHTTP(httprec, r)
 			responseReceived := time.Now()
 

--- a/middleware.go
+++ b/middleware.go
@@ -1,7 +1,9 @@
 package httprecorder
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -9,11 +11,25 @@ import (
 )
 
 type Recorder interface {
-	Record(req *http.Request, resp *http.Response, requestReceived time.Time, responseReceived time.Time) error
+	Record(req *http.Request, requestBody []byte, resp *http.Response, requestReceived time.Time, responseReceived time.Time) error
 	Length() int
 	GetInteractions(start int, length int) []Interaction
 	GetInteraction(index int) Interaction
 	Clear()
+}
+
+func replaceBody(r *http.Request) ([]byte, error) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
+
+	if len(b) == 0 {
+		b = nil
+	}
+	return b, nil
 }
 
 func Middleware(recorder Recorder) func(http.Handler) http.Handler {
@@ -22,11 +38,13 @@ func Middleware(recorder Recorder) func(http.Handler) http.Handler {
 			requestReceived := time.Now()
 			httprec := httptest.NewRecorder()
 
+			requestBody, err := replaceBody(r)
+
 			next.ServeHTTP(httprec, r)
 			responseReceived := time.Now()
 
 			resp := httprec.Result()
-			err := recorder.Record(r, resp, requestReceived, responseReceived)
+			err = recorder.Record(r, requestBody, resp, requestReceived, responseReceived)
 			if err != nil {
 				// TODO what to do here?
 				log.Print("Error in recorder middleware: " + err.Error())


### PR DESCRIPTION
We're currently attempting to read a request body _after_ it has been sent off upstream and therefore has been already read and closed. This causes panics with attempts to read a closed body.

This fixes the middleware to read and replace the body before sending it to the next handler.

# WIP

This code is a little gross and rushed