### PR TITLE
Add proxy example

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,0 +1,17 @@
+FROM golang:alpine AS builder
+
+WORKDIR /go/src/github.com/porty/httprecorder
+COPY . .
+
+RUN apk add -U git
+RUN \
+    cd examples/proxy && \
+    go get -d . && \
+    CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o /proxy .
+
+FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /proxy /proxy
+
+ENTRYPOINT ["/proxy"]

--- a/examples/proxy/main.go
+++ b/examples/proxy/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/porty/httprecorder"
+)
+
+type Config struct {
+	ProxyPort    int    `envconfig:"PROXY_PORT" required:"true"`
+	RecorderPort int    `envconfig:"RECORDER_PORT" required:"true"`
+	Upstream     string `envconfig:"UPSTREAM" required:"true"`
+	MaxRequests  int    `envconfig:"MAX_REQUESTS" default:"100"`
+}
+
+func main() {
+	_ = godotenv.Load(".env")
+	var config Config
+	if err := envconfig.Process("", &config); err != nil {
+		log.Print("Failed to process config: " + err.Error())
+		os.Exit(1)
+	}
+
+	upstream, err := url.Parse(config.Upstream)
+	if err != nil {
+		panic(err)
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = upstream.Scheme
+			req.URL.Host = upstream.Host
+			req.Host = upstream.Host
+		},
+	}
+
+	recorder := httprecorder.NewMemoryRecorder(config.MaxRequests)
+	proxyAddr := fmt.Sprintf(":%d", config.ProxyPort)
+	recorderAddr := fmt.Sprintf(":%d", config.RecorderPort)
+	log.Printf("Listening on %s for proxy requests to %s", proxyAddr, config.Upstream)
+	log.Printf("Listening on %s for the HTTP Recorder interface", recorderAddr)
+
+	errs := make(chan error)
+
+	go func() {
+		errs <- http.ListenAndServe(proxyAddr, httprecorder.Middleware(recorder)(proxy))
+	}()
+	go func() {
+		errs <- http.ListenAndServe(recorderAddr, httprecorder.UIHandler(recorder))
+	}()
+
+	err = <-errs
+	panic(err)
+}


### PR DESCRIPTION
An example program that acts as a proxy to a single endpoint, based on environment variables. Docker-friendly.

# TODO

* README
